### PR TITLE
Adds functionality and tests for readavailable

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -66,8 +66,6 @@ end
 # n-ary functions
 Base.seek(s::TruncatedIO, n::Integer) = seek(unwrap(s), n)
 Base.skip(s::TruncatedIO, n::Integer) = skip(unwrap(s), n)
-Base.unsafe_read(s::TruncatedIO, p::Ptr{UInt8}, n::UInt) = unsafe_read(unwrap(s), p, n)
-Base.unsafe_write(s::TruncatedIO, p::Ptr{UInt8}, n::UInt) = unsafe_write(unwrap(s), p, n)
 
 # required to override byte-level reading of objects by delegating to unsafe_read
 function Base.read(s::TruncatedIO, ::Type{UInt8})
@@ -75,3 +73,9 @@ function Base.read(s::TruncatedIO, ::Type{UInt8})
     unsafe_read(s, r, 1)
     return r[]
 end
+
+# allows bytesavailable to signal how much can be read from the stream at a time
+Base.readavailable(s::TruncatedIO) = read(s, bytesavailable(s))
+
+# required to allow passthrough of byte-level writing
+Base.write(s::TruncatedIO, x::UInt8) = return write(unwrap(s), x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -334,4 +334,60 @@ end
     @test eof(fio)
 end
 
+@testitem "write" begin
+    content = collect(0x00:0x0f)
+    io = IOBuffer(content; read=true, write=true, append=true)
+
+    fixed_length = 17
+    fio = FixedLengthIO(io, fixed_length) # note: stream isn't long enough yet!
+
+    @test read(fio) == content
+
+    seekstart(fio)
+    @test write(fio, [0x10, 0x11]) == 2 # note: append flag above sets write poionter to the end of the stream, while seekstart 
+    @test position(fio) == 0 # write did not change the number of bytes read
+    @test position(io) == 0 # write MAY change the position of the read wrapped buffer, though, so be wary!
+
+    @test read(fio) == collect(0x00:0x10)
+    @test position(fio) == fixed_length
+    @test eof(fio)
+    @test !eof(io)
+
+    seekstart(io)
+    sentinel = [0x11, 0x12]
+    sio = SentinelIO(io, sentinel) # note: sentinel doesn't exist in the stream yet!
+
+    @test_throws EOFError read(sio) # no sentinel found
+    
+    seekstart(sio)
+    @test write(sio, [0x12, 0x13]) == 2 # complete the sentinel by appending
+    @test position(sio) == 0
+    
+    @test read(sio) == collect(0x00:0x10)
+    @test eof(sio)
+    @test !eof(io)
+end
+
+@testitem "readavailable" begin
+    # readavailable is passed through to underlying stream
+    # it's implementation-dependent, so just check to make sure it works and doesn't throw
+    content = collect(0x00:0xff)
+    io = IOBuffer(content; read=true, write=true, append=true)
+
+    fixed_length = 16
+    fio = FixedLengthIO(io, fixed_length)
+
+    r = readavailable(fio)
+    @test length(r) <= fixed_length
+    @test r == first(content, length(r))
+
+    seekstart(io)
+    sentinel = content[fixed_length+1:fixed_length+2]
+    sio = SentinelIO(io, sentinel)
+
+    r = readavailable(sio)
+    @test length(r) <= fixed_length
+    @test r == first(content, length(r))
+end
+
 @run_package_tests verbose = true


### PR DESCRIPTION
Because this addresses the write(::IO, ::TruncatedIO) issue, it also reimplementes byte-wise reading and writing for TruncatedIO.