### PR TITLE
Fix `FixedLengthIO` `unsafe_read`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,4 +390,26 @@ end
     @test r == first(content, length(r))
 end
 
+@testitem "read!" begin
+    # read! is passed through to underlying stream using unsafe_read
+    content = collect(0x00:0xff)
+    path = tempname()
+    write(path, content)
+    open(path) do io
+        fixed_length = 16
+        fio = FixedLengthIO(io, fixed_length)
+        out = zeros(UInt8, fixed_length)
+        read!(fio, out)
+        @test out == content[1:fixed_length]
+    end
+    open(path) do io
+        fixed_length = 16
+        sentinel = content[fixed_length+1:fixed_length+2]
+        sio = SentinelIO(io, sentinel)
+        out = zeros(UInt8, fixed_length)
+        read!(sio, out)
+        @test out == content[1:fixed_length]
+    end
+end
+
 @run_package_tests verbose = true


### PR DESCRIPTION
I'm using ideas from https://github.com/JuliaIO/TranscodingStreams.jl/blob/130a1ff0b8c7ea047d3acf1b591c30ec2f5797de/src/stream.jl#L380-L395 to fix `unsafe_read` for `FixedLengthIO`. The issue with the current method is that some `IO` may have `bytesavailable` of zero, even if they are not at the end of the file, and a call to `eof` in a loop is needed to refill the buffered data.