### PR TITLE
9 can truncatedio be read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ using TruncatedStreams
 
 io = IOBuffer(collect(0x00:0xff))
 
-fixed_io = FixedLengthIO(io, 10)  # pretend EOF occurs after the first 10 bytes are read
+fixed_io = FixedLengthSource(io, 10)  # pretend EOF occurs after the first 10 bytes are read
 @assert read(fixed_io) == collect(0x00:0x09)
 @assert eof(fixed_io) == true
 @assert eof(io) == false  # a lie, but a useful one!
 @assert peek(io) == 0x0a  # read exactly 10 bytes from io and not a byte more
 
-sentinel_io = SentinelIO(io, [0x10, 0x11])  # pretend EOF occurs as soon as the sentinel is read
+sentinel_io = SentinelizedSource(io, [0x10, 0x11])  # pretend EOF occurs as soon as the sentinel is read
 @assert read(sentinel_io) == collect(0x0a:0x0f)
 @assert eof(sentinel_io) == true
 @assert eof(io) == false
@@ -68,16 +68,16 @@ using Pkg; Pkg.install("TruncatedStreams")
 
 ## Use
 
-### `FixedLengthIO`
+### `FixedLengthSource`
 
-`FixedLengthIO` wraps an `IO` object and will read from it until a certain number of bytes is read, after which `FixedLengthIO` will act as if it has reached the end of the file:
+`FixedLengthSource` wraps an `IO` object and will read from it until a certain number of bytes is read, after which `FixedLengthSource` will act as if it has reached the end of the file:
 
 ```julia
 julia> using TruncatedStreams
 
 julia> io = IOBuffer(collect(0x00:0xff));
 
-julia> fio = FixedLengthIO(io, 10);  # Only read the next 10 bytes
+julia> fio = FixedLengthSource(io, 10);  # Only read the next 10 bytes
 
 julia> read(fio, UInt64)  # First 8 bytes
 0x0706050403020100
@@ -91,16 +91,16 @@ julia> eof(fio)  # It's a lie, but it's a useful one!
 true
 ```
 
-### `SentinelIO`
+### `SentinelizedSource`
 
-`SentinelIO` wraps an `IO` object and will read from in until a sentinel is found, after which `SentinelIO` will act as if it has reached the end of the file, discarding the sentinel:
+`SentinelizedSource` wraps an `IO` object and will read from in until a sentinel is found, after which `SentinelizedSource` will act as if it has reached the end of the file, discarding the sentinel:
 
 ```julia
 julia> using TruncatedStreams
 
 julia> io = IOBuffer(collect(0x00:0xff));
 
-julia> sio = SentinelIO(io, [0x10, 0x11, 0x12]);  # Only read until [0x10, 0x11, 0x12] is found
+julia> sio = SentinelizedSource(io, [0x10, 0x11, 0x12]);  # Only read until [0x10, 0x11, 0x12] is found
 
 julia> read(sio, UInt64)  # First 8 bytes
 0x0706050403020100

--- a/src/TruncatedStreams.jl
+++ b/src/TruncatedStreams.jl
@@ -1,14 +1,14 @@
 module TruncatedStreams
 
-export TruncatedIO
-export FixedLengthIO
-export SentinelIO
+export TruncatedSource
+export FixedLengthSource
+export SentinelizedSource
 
 @static if VERSION < v"1.7"
     include("compat.jl")
 end
 include("io.jl")
-include("fixedlengthio.jl")
-include("sentinelio.jl")
+include("fixedlength.jl")
+include("sentinel.jl")
 
 end

--- a/src/fixedlength.jl
+++ b/src/fixedlength.jl
@@ -1,12 +1,12 @@
 """
-    FixedLengthIO(io, length) <: TruncatedIO
+    FixedLengthSource(io, length) <: TruncatedSource
 
 A truncated source that reads `io` up to `length` bytes.
 
 ```jldoctest fixedlengthio_1
 julia> io = IOBuffer(collect(0x00:0xff));
 
-julia> fio = FixedLengthIO(io, 10);
+julia> fio = FixedLengthSource(io, 10);
 
 julia> read(fio)
 10-element Vector{UInt8}:
@@ -25,7 +25,7 @@ julia> eof(fio)
 true
 ```
 
-As soon as a read from a `FixedLengthIO` object would read past `length` bytes of the
+As soon as a read from a `FixedLengthSource` object would read past `length` bytes of the
 underlying IO stream, EOF is signalled, potentially leading to an `EOFError` being thrown.
 
 ```jldoctest fixedlengthio_1
@@ -44,11 +44,11 @@ julia> seek(fio, 8); read(fio)
  0x09
 ```
 
-Writing to a `FixedLengthIO` object does not affect the length at which the stream is
+Writing to a `FixedLengthSource` object does not affect the length at which the stream is
 truncated, but may affect how many bytes are available to read.
 
 ```jldoctest fixedlengthio_2
-julia> io = IOBuffer(collect(0x00:0x05); read=true, write=true); fio = FixedLengthIO(io, 10);
+julia> io = IOBuffer(collect(0x00:0x05); read=true, write=true); fio = FixedLengthSource(io, 10);
 
 julia> read(fio)
 6-element Vector{UInt8}:
@@ -77,21 +77,21 @@ julia> read(fio)
  0x09
 ```
 """
-mutable struct FixedLengthIO{S<:IO} <: TruncatedIO
+mutable struct FixedLengthSource{S<:IO} <: TruncatedSource
     wrapped::S
     length::Int64
     remaining::Int64
 
-    FixedLengthIO(io::S, length::Integer) where {S} = new{S}(io, length, length)
+    FixedLengthSource(io::S, length::Integer) where {S} = new{S}(io, length, length)
 end
 
-unwrap(s::FixedLengthIO) = s.wrapped
+unwrap(s::FixedLengthSource) = s.wrapped
 
-Base.bytesavailable(s::FixedLengthIO) = min(s.remaining, bytesavailable(unwrap(s)))
+Base.bytesavailable(s::FixedLengthSource) = min(s.remaining, bytesavailable(unwrap(s)))
 
-Base.eof(s::FixedLengthIO) = eof(unwrap(s)) || s.remaining <= 0
+Base.eof(s::FixedLengthSource) = eof(unwrap(s)) || s.remaining <= 0
 
-function Base.unsafe_read(s::FixedLengthIO, p::Ptr{UInt8}, n::UInt)
+function Base.unsafe_read(s::FixedLengthSource, p::Ptr{UInt8}, n::UInt)
     # note that the convention from IOBuffer is to read as much as possible first,
     # then throw EOF if the requested read was beyond the number of bytes available.
     available = bytesavailable(s)
@@ -104,16 +104,16 @@ function Base.unsafe_read(s::FixedLengthIO, p::Ptr{UInt8}, n::UInt)
     return nothing
 end
 
-function Base.seek(s::FixedLengthIO, n::Integer)
+function Base.seek(s::FixedLengthSource, n::Integer)
     pos = clamp(Int64(n), Int64(0), s.length)
     s.remaining = s.length - pos
     seek(unwrap(s), pos)
     return s
 end
 
-Base.seekend(s::FixedLengthIO) = seek(s, s.length)
+Base.seekend(s::FixedLengthSource) = seek(s, s.length)
 
-function Base.skip(s::FixedLengthIO, n::Integer)
+function Base.skip(s::FixedLengthSource, n::Integer)
     # negative numbers will add bytes back to bytesremaining
     bytes = clamp(Int64(n), s.remaining - s.length, s.remaining)
     s.remaining -= bytes
@@ -121,7 +121,7 @@ function Base.skip(s::FixedLengthIO, n::Integer)
     return s
 end
 
-function Base.reset(s::FixedLengthIO)
+function Base.reset(s::FixedLengthSource)
     pos = reset(unwrap(s))
     seek(s, pos) # seeks the underlying stream as well, but that should be a noop
     return pos

--- a/src/fixedlength.jl
+++ b/src/fixedlength.jl
@@ -43,39 +43,6 @@ julia> seek(fio, 8); read(fio)
  0x08
  0x09
 ```
-
-Writing to a `FixedLengthSource` object does not affect the length at which the stream is
-truncated, but may affect how many bytes are available to read.
-
-```jldoctest fixedlengthio_2
-julia> io = IOBuffer(collect(0x00:0x05); read=true, write=true); fio = FixedLengthSource(io, 10);
-
-julia> read(fio)
-6-element Vector{UInt8}:
- 0x00
- 0x01
- 0x02
- 0x03
- 0x04
- 0x05
-
-julia> write(fio, collect(0x06:0xff));
-
-julia> seekstart(fio);  # writing advances the IOBuffer's read pointer
-
-julia> read(fio)
-10-element Vector{UInt8}:
- 0x00
- 0x01
- 0x02
- 0x03
- 0x04
- 0x05
- 0x06
- 0x07
- 0x08
- 0x09
-```
 """
 mutable struct FixedLengthSource{S<:IO} <: TruncatedSource
     wrapped::S

--- a/src/fixedlength.jl
+++ b/src/fixedlength.jl
@@ -94,11 +94,24 @@ Base.eof(s::FixedLengthSource) = eof(unwrap(s)) || s.remaining <= 0
 function Base.unsafe_read(s::FixedLengthSource, p::Ptr{UInt8}, n::UInt)
     # note that the convention from IOBuffer is to read as much as possible first,
     # then throw EOF if the requested read was beyond the number of bytes available.
-    available = bytesavailable(s)
-    to_read = min(available, n)
-    unsafe_read(unwrap(s), p, to_read)
-    s.remaining -= to_read
-    if to_read < n
+    @assert !signbit(s.remaining)
+    p_end = p + n
+    while p != p_end && !eof(s)
+        m = UInt(min(p_end - p, bytesavailable(s)))
+        if iszero(m)
+            b = read(unwrap(s), UInt8)
+            unsafe_store!(p, b)
+            p += UInt(1)
+            s.remaining -= 1
+        else
+            # This must not throw due to bytesavailable check
+            unsafe_read(unwrap(s), p, m)
+            p += m
+            s.remaining -= m
+        end
+    end
+    @assert !signbit(s.remaining)
+    if p != p_end
         throw(EOFError())
     end
     return nothing

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,37 +1,40 @@
 """
-    TruncatedIO <: IO
+    TruncatedSource <: IO
 
-Wraps a streaming IO object that reads only as much as should be read and not a byte more.
+Wrap an IO object to read only as much as should be read and not a byte more.
 
-Objects inheriting from this abstract type pass along all IO methods to the wrapped stream
-except for `bytesavailable(io)` and `eof(io)`. Inherited types _must_ implement:
-- `TruncatedStreams.unwrap(::TruncatedIO)::IO`: return the wrapped IO stream.
-- `Base.eof(::TruncatedIO)::Bool`: report whether the stream cannot produce any more bytes.
+Objects inheriting from this abstract type pass along all read-oriented IO methods to the wrapped
+stream except for `bytesavailable(io)` and `eof(io)`. Inherited types _must_ implement:
+- `TruncatedStreams.unwrap(::TruncatedSource)::IO`: return the wrapped IO stream.
+- `Base.eof(::TruncatedSource)::Bool`: report whether the stream cannot produce any more bytes.
 
-In order to implement truncation, some number of these methods will likely need to be
-implemented:
-- `Base.unsafe_read(::TruncatedIO, p::Ptr{UInt8}, n::UInt)::Nothing`: copy `n` bytes from the stream into memory pointed to by `p`.
-- `Base.read(::TruncatedIO, T::Type)::T`: read and return an object of type `T` from the stream.
-- `Base.bytesavailable(::TruncatedIO)::Int`: report the number of bytes available to read from the stream until EOF or a buffer refill.
-- `Base.seek(::TruncatedIO, p::Integer)` and `Base.seekend(::TruncatedIO)`: seek stream to position `p` or end of stream.
-- `Base.reset(::TruncatedIO)`: reset a marked stream to the saved position.
-- `Base.reseteof(::TruncatedIO)::Nothing`: reset EOF status.
+In order to implement truncation, some number of these methods will likely need to be implemented:
+- `Base.unsafe_read(::TruncatedSource, p::Ptr{UInt8}, n::UInt)::Nothing`: copy `n` bytes from the
+    stream into memory pointed to by `p`.
+- `Base.read(::TruncatedSource, T::Type)::T`: read and return an object of type `T` from the stream.
+- `Base.bytesavailable(::TruncatedSource)::Int`: report the number of bytes available to read from
+    the stream until EOF or a buffer refill is necessary.
+- `Base.seek(::TruncatedSource, p::Integer)` and `Base.seekend(::TruncatedSource)`: seek stream to
+    position `p` or end of stream.
+- `Base.reset(::TruncatedSource)`: reset a marked stream to the saved position.
+- `Base.reseteof(::TruncatedSource)::Nothing`: reset EOF status.
+- `Base.peek(::TruncatedSource[, T::Type])::T`: read and return the next object of type `T` from the
+    stream, but leave the bytes available in the stream for the next read.
 
-Note that writing to the stream does not affect truncation.
-
-The following methods must be implemented by the wrapped IO type for all the functionality
-of the truncated streams to work at all:
+The following methods _must_ be implemented by the wrapped IO type for all the functionality of the
+    `TruncatedSource` to work at all:
 - `Base.eof(::IO)::Bool`
 - `Base.read(::IO, ::Type{UInt8})::UInt8`
 
-The wrapped stream also must implement `Base.seek` and `Base.skip` for seeking and skipping
-of the truncated stream to work properly. Additionally, `Base.position` needs to be
-implemented for some instances of `Base.seek` to work properly.
+The wrapped stream also must implement `Base.seek` and `Base.skip` for seeking and skipping of the
+truncated stream to work properly. Additionally, `Base.position` needs to be implemented for some
+implementations of `Base.seek` to work properly.
 """
-abstract type TruncatedIO <: IO end
+abstract type TruncatedSource <: IO end
+
 
 """
-    unwrap(s<:TruncatedIO) -> IO
+    unwrap(s<:TruncatedSource{T}) -> T where {T <: IO}
 
 Return the wrapped source.
 """
@@ -43,34 +46,25 @@ for func in (
     :unlock,
     :isopen,
     :close,
-    :flush,
     :position,
     :mark,
     :unmark,
     :reset,
     :ismarked,
     :isreadable,
-    :iswritable,
 )
-    @eval Base.$func(s::TruncatedIO) = Base.$func(unwrap(s))
+    @eval Base.$func(s::TruncatedSource) = Base.$func(unwrap(s))
 end
 
-# newer functions for half-duplex close
-@static if VERSION >= v"1.8"
-    for func in (:closewrite,)
-        @eval Base.$func(s::TruncatedIO) = Base.$func(unwrap(s))
-    end
-end
+# always report unwritable
+Base.iswritable(::TruncatedSource) = false
 
 # required to override byte-level reading of objects by delegating to unsafe_read
-function Base.read(s::TruncatedIO, ::Type{UInt8})
+function Base.read(s::TruncatedSource, ::Type{UInt8})
     r = Ref{UInt8}()
     unsafe_read(s, r, 1)
     return r[]
 end
 
 # allows bytesavailable to signal how much can be read from the stream at a time
-Base.readavailable(s::TruncatedIO) = read(s, bytesavailable(s))
-
-# required to allow passthrough of byte-level writing
-Base.write(s::TruncatedIO, x::UInt8) = return write(unwrap(s), x)
+Base.readavailable(s::TruncatedSource) = read(s, bytesavailable(s))

--- a/src/sentinel.jl
+++ b/src/sentinel.jl
@@ -4,7 +4,7 @@
 A truncated source that reads `io` until `sentinel` is found.
 
 ```jldoctest sentinelio_1
-julia> io = IOBuffer(collect(0x00:0xff));
+julia> io = IOBuffer(repeat(collect(0x00:0x0f), 2));
 
 julia> sio = SentinelizedSource(io, [0x0a, 0x0b]);
 
@@ -49,18 +49,27 @@ julia> seek(sio, 8); read(sio)
 Detection of eof can be reset with the `Base.reseteof()` method. Use this if the sentinel
 that was read is determined upon further inspection to be bogus.
 
-```jldoctest sentinelio_2
+```jldoctest sentinelio_1
 julia> Base.reseteof(sio)  # that last sentinel was fake, so reset EOF and read again
 
 julia> read(sio)  # returns the first sentinel found and continues to read until the next one is found
-7-element Vector{UInt8}:
- 0x06
- 0x07
+16-element Vector{UInt8}:
+ 0x0a
+ 0x0b
+ 0x0c
+ 0x0d
+ 0x0e
+ 0x0f
+ 0x00
  0x01
  0x02
  0x03
  0x04
  0x05
+ 0x06
+ 0x07
+ 0x08
+ 0x09
 ```
 
 !!! note

--- a/src/sentinel.jl
+++ b/src/sentinel.jl
@@ -1,12 +1,12 @@
 """
-    SentinelIO(io, sentinel) <: TruncatedIO
+    SentinelizedSource(io, sentinel) <: TruncatedSource
 
 A truncated source that reads `io` until `sentinel` is found.
 
 ```jldoctest sentinelio_1
 julia> io = IOBuffer(collect(0x00:0xff));
 
-julia> sio = SentinelIO(io, [0x0a, 0x0b]);
+julia> sio = SentinelizedSource(io, [0x0a, 0x0b]);
 
 julia> read(sio)
 10-element Vector{UInt8}:
@@ -25,7 +25,7 @@ julia> eof(sio)
 true
 ```
 
-As soon as a read from a `SentinelIO` object would read the start of a byte sequence
+As soon as a read from a `SentinelizedSource` object would read the start of a byte sequence
 matching `sentinel` from the underlying IO stream, EOF is signalled, potentially leading to
 an `EOFError` being thrown.
 
@@ -43,36 +43,6 @@ julia> seek(sio, 8); read(sio)
 2-element Vector{UInt8}:
  0x08
  0x09
-```
-
-Writing to a `SentinelIO` object does not affect the length at which the stream is
-truncated, but may affect how many bytes are available to read.
-
-
-```jldoctest sentinelio_2
-julia> io = IOBuffer(collect(0x00:0x07); read=true, write=true); sio = SentinelIO(io, [0x06, 0x07]);
-
-julia> read(sio)
-6-element Vector{UInt8}:
- 0x00
- 0x01
- 0x02
- 0x03
- 0x04
- 0x05
-
-julia> write(sio, collect(0x01:0xff));
-
-julia> seekstart(sio);  # writing advances the IOBuffer's read pointer
-
-julia> read(sio)  # still the same output because the sentinel is still there
-6-element Vector{UInt8}:
- 0x00
- 0x01
- 0x02
- 0x03
- 0x04
- 0x05
 ```
 
 Detection of eof can be reset with the `Base.reseteof()` method. Use this if the sentinel
@@ -97,14 +67,14 @@ julia> read(sio)  # returns the first sentinel found and continues to read until
     throw `EOFError`.
 
 ```jldoctest sentinelio_3
-julia> io = IOBuffer(collect(0x00:0x07)); sio = SentinelIO(io, [0xff, 0xfe]);
+julia> io = IOBuffer(collect(0x00:0x07)); sio = SentinelizedSource(io, [0xff, 0xfe]);
 
 julia> read(sio)
 ERROR: EOFError: read end of file
 [...]
 ```
 """
-mutable struct SentinelIO{S<:IO} <: TruncatedIO
+mutable struct SentinelizedSource{S<:IO} <: TruncatedSource
     wrapped::S
     sentinel::Vector{UInt8}
     buffer::Vector{UInt8}
@@ -112,7 +82,7 @@ mutable struct SentinelIO{S<:IO} <: TruncatedIO
     skip_next_eof::Bool
     buffer_length_at_mark::Int
 
-    function SentinelIO(io::S, sentinel::AbstractVector{UInt8}) where {S<:IO}
+    function SentinelizedSource(io::S, sentinel::AbstractVector{UInt8}) where {S<:IO}
         sen = Vector{UInt8}(sentinel) # so I have a real Vector
         ns = length(sen)
         # generate the failure function for the Knuth–Morris–Pratt algorithm
@@ -138,12 +108,12 @@ mutable struct SentinelIO{S<:IO} <: TruncatedIO
     end
 end
 
-SentinelIO(io::IO, sentinel::AbstractString) = SentinelIO(io, codeunits(sentinel))
+SentinelizedSource(io::IO, sentinel::AbstractString) = SentinelizedSource(io, codeunits(sentinel))
 
-unwrap(s::SentinelIO) = s.wrapped
+unwrap(s::SentinelizedSource) = s.wrapped
 
 # count the number of bytes before a prefix match on the next sentinel
-function count_safe_bytes(s::SentinelIO, stop_early::Bool=false)
+function count_safe_bytes(s::SentinelizedSource, stop_early::Bool=false)
     nb = length(s.buffer)
 
     if eof(unwrap(s))
@@ -192,18 +162,18 @@ function count_safe_bytes(s::SentinelIO, stop_early::Bool=false)
     end
 end
 
-Base.bytesavailable(s::SentinelIO) = count_safe_bytes(s)
+Base.bytesavailable(s::SentinelizedSource) = count_safe_bytes(s)
 
-Base.eof(s::SentinelIO) = count_safe_bytes(s, true) == 0
+Base.eof(s::SentinelizedSource) = count_safe_bytes(s, true) == 0
 
 # fill the first n bytes of the buffer from the wrapped stream, overwriting what is there
-function fill_buffer(s::SentinelIO, n::Integer=length(s.sentinel))
+function fill_buffer(s::SentinelizedSource, n::Integer=length(s.sentinel))
     to_read = min(n, length(s.sentinel))
     nb = readbytes!(unwrap(s), s.buffer, to_read)
     return nb
 end
 
-function Base.unsafe_read(s::SentinelIO, p::Ptr{UInt8}, n::UInt)
+function Base.unsafe_read(s::SentinelizedSource, p::Ptr{UInt8}, n::UInt)
     # read available bytes, checking for sentinel each time
     to_read = n
     ptr = 0
@@ -244,9 +214,9 @@ function Base.unsafe_read(s::SentinelIO, p::Ptr{UInt8}, n::UInt)
     return nothing
 end
 
-Base.position(s::SentinelIO) = position(unwrap(s)) - length(s.buffer)  # lie about where we are in the stream
+Base.position(s::SentinelizedSource) = position(unwrap(s)) - length(s.buffer)  # lie about where we are in the stream
 
-function Base.seek(s::SentinelIO, n::Integer)
+function Base.seek(s::SentinelizedSource, n::Integer)
     # seeking backwards is only possible if the wrapped stream allows it.
     # seeking forwards is easier done as reading and dumping data.
     pos = max(n, 0)
@@ -262,7 +232,7 @@ function Base.seek(s::SentinelIO, n::Integer)
     else
         # drop remainder on the floor
         while bytes > 0 && !eof(s)
-            # if the number of bytes is too large, reading everything at once will cause a out-of-memory error, so read to EOF instead
+            # if the number of bytes is too large, reading everything at once will cause a out-of-memory error, so read byte-by-byte instead
             read(s, UInt8)
             bytes -= 1
         end
@@ -270,12 +240,12 @@ function Base.seek(s::SentinelIO, n::Integer)
     return s
 end
 
-function Base.seekend(s::SentinelIO)
-    write(devnull, s) # read until the end
+function Base.seekend(s::SentinelizedSource)
+    write(devnull, s) # read until sentinel is found
     return s
 end
 
-function Base.skip(s::SentinelIO, bytes::Integer)
+function Base.skip(s::SentinelizedSource, bytes::Integer)
     # skipping backwards is only possible if the wrapped stream allows it.
     # skipping forwards is easier done as reading and dumping data.
     if bytes <= 0
@@ -293,7 +263,7 @@ function Base.skip(s::SentinelIO, bytes::Integer)
     return s
 end
 
-function Base.mark(s::SentinelIO)
+function Base.mark(s::SentinelizedSource)
     pos = mark(unwrap(s))
     # lie about where we are in the stream
     # noting that the length of the buffer might change
@@ -302,7 +272,7 @@ function Base.mark(s::SentinelIO)
     return pos - nb
 end
 
-function Base.reset(s::SentinelIO)
+function Base.reset(s::SentinelizedSource)
     pos = reset(unwrap(s))
     # refill the buffer manually, which should be guaranteed to work, but check just in case
     seek(unwrap(s), pos - s.buffer_length_at_mark)
@@ -314,7 +284,7 @@ function Base.reset(s::SentinelIO)
     return pos - s.buffer_length_at_mark
 end
 
-function Base.reseteof(s::SentinelIO)
+function Base.reseteof(s::SentinelizedSource)
     Base.reseteof(unwrap(s))
     s.skip_next_eof = true
     return nothing


### PR DESCRIPTION
Attempts to address #9 by making all exported stream wrappers read-only. Necessitated a change in names.